### PR TITLE
Add BLE battery sensor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Copy all files in the `custom_components`/`yeelock` folder to your Home Assistan
 ## Future enhancements
 Your support is welcomed.
 
-- Add battery level sensor
 - Add option to unlock automatically if battery gets too low
 
 # Acknowledgements

--- a/custom_components/yeelock/const.py
+++ b/custom_components/yeelock/const.py
@@ -6,6 +6,7 @@ DOMAIN = "yeelock"
 
 PLATFORMS: list[str] = [
     Platform.LOCK,
+    Platform.SENSOR,
 ]
 
 CONF_PHONE = "phone"

--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -159,93 +159,48 @@ class Yeelock:
             _LOGGER.debug("Notified of %s", new_state)
             await self._lock._update_lock_state(new_state)
 
-    def _encrypt(self, unlock_mode):
-        """Encrypt the data."""
-        # Given values
-        unlock_command = 0x01
-        admin_identification_mode = 0x50
-        key = bytearray.fromhex(self.key)
+    def _encrypt_command(
+        self, command: int, admin_identification_mode: int, payload: bytes = b""
+    ) -> bytes:
+        """Encrypt a command packet.
 
-        # Convert epoch time to a human-readable date and time
+        The protocol frames are 20 bytes long and include:
+        command + admin mode + timestamp + optional payload + HMAC-SHA1 fragment.
+        """
+        key = bytearray.fromhex(self.key)
         timestamp = int(time())
 
-        # Generate the HMAC
         message = (
-            unlock_command.to_bytes(1, "big")
+            command.to_bytes(1, "big")
             + admin_identification_mode.to_bytes(1, "big")
             + timestamp.to_bytes(4, "big")
-            + int(unlock_mode, 16).to_bytes(1, "big")
+            + payload
         )
+        signature_length = 20 - len(message)
         hmac_result = bytearray.fromhex(
-            hmac.new(key, message[:7], hashlib.sha1).hexdigest()
-        )[:13]
+            hmac.new(key, message, hashlib.sha1).hexdigest()
+        )[:signature_length]
+        return message + hmac_result
 
-        # Concatenate all the parts to create the output value as a bytearray
-        output_value = (
-            unlock_command.to_bytes(1, "big")
-            + admin_identification_mode.to_bytes(1, "big")
-            + timestamp.to_bytes(4, "big")
-            + int(unlock_mode, 16).to_bytes(1, "big")
-            + hmac_result
+    def _encrypt(self, unlock_mode):
+        """Encrypt lock and unlock command packets."""
+        output_value = self._encrypt_command(
+            command=0x01,
+            admin_identification_mode=0x50,
+            payload=int(unlock_mode, 16).to_bytes(1, "big"),
         )
-
         _LOGGER.debug("Sent transactional msg %s", output_value)
         return output_value
 
     def _encrypt_time(self):
-        """Encrypt the time."""
-        # Given values
-        unlock_command = 0x08
-        admin_identification_mode = 0x40
-        key = bytearray.fromhex(self.key)
-
-        # Convert epoch time to a human-readable date and time
-        timestamp = int(time())
-
-        # Generate the HMAC
-        message = (
-            unlock_command.to_bytes(1, "big")
-            + admin_identification_mode.to_bytes(1, "big")
-            + timestamp.to_bytes(4, "big")
-        )
-        hmac_result = bytearray.fromhex(
-            hmac.new(key, message[:6], hashlib.sha1).hexdigest()
-        )[:14]
-
-        # Concatenate all the parts to create the output value as a bytearray
-        output_value = (
-            unlock_command.to_bytes(1, "big")
-            + admin_identification_mode.to_bytes(1, "big")
-            + timestamp.to_bytes(4, "big")
-            + hmac_result
-        )
-
+        """Encrypt the time sync command packet."""
+        output_value = self._encrypt_command(command=0x08, admin_identification_mode=0x40)
         _LOGGER.debug("Sent time sync msg %s", output_value)
         return output_value
 
     def _encrypt_battery(self):
-        """Encrypt the battery request command."""
-        battery_command = 0x06
-        admin_identification_mode = 0x40
-        key = bytearray.fromhex(self.key)
-        timestamp = int(time())
-
-        message = (
-            battery_command.to_bytes(1, "big")
-            + admin_identification_mode.to_bytes(1, "big")
-            + timestamp.to_bytes(4, "big")
-        )
-        hmac_result = bytearray.fromhex(
-            hmac.new(key, message[:6], hashlib.sha1).hexdigest()
-        )[:14]
-
-        output_value = (
-            battery_command.to_bytes(1, "big")
-            + admin_identification_mode.to_bytes(1, "big")
-            + timestamp.to_bytes(4, "big")
-            + hmac_result
-        )
-
+        """Encrypt the battery request command packet."""
+        output_value = self._encrypt_command(command=0x06, admin_identification_mode=0x40)
         _LOGGER.debug("Sent battery msg %s", output_value)
         return output_value
 

--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -216,6 +216,10 @@ class Yeelock:
         except BleakError as error:
             self._connected = False
             _LOGGER.error("BleakError: %s", error)
+        finally:
+            # Refresh battery after lock activity when the battery entity exists.
+            if self._battery_sensor is not None:
+                await self.update_battery()
 
     async def time_sync(self) -> None:
         """Time sync and retry."""
@@ -231,7 +235,7 @@ class Yeelock:
             _LOGGER.error("BleakError: %s", error)
 
     async def update_battery(self) -> None:
-        """Request battery level."""
+        """Request battery level from the lock over BLE."""
         await self._connect()
         try:
             _LOGGER.debug("Requesting battery level")

--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -52,6 +52,7 @@ class Yeelock:
         self._hass = hass
         self._device = None
         self._lock = None
+        self._battery_sensor = None
         self._client = None
         self._connecting = False
         self._connected = False
@@ -60,6 +61,7 @@ class Yeelock:
         self.key = config.get(CONF_API_KEY)
         self.model = config.get(CONF_MODEL, None)
         self.manufacturer = "Yeelock"
+        self.battery_level = None
 
     async def disconnect(self):
         """Disconnect from the device."""
@@ -138,6 +140,16 @@ class Yeelock:
                 await self.locker(self._last_action)
                 self._last_action = None
 
+        # Battery response notification
+        elif first_byte == hex(0x7):
+            if len(value) > 6:
+                self.battery_level = value[6]
+                _LOGGER.debug("Received battery level: %s%%", self.battery_level)
+                if self._battery_sensor is not None:
+                    await self._battery_sensor._update_battery_level(self.battery_level)
+            else:
+                _LOGGER.warning("Battery notification too short: %s", received_message)
+
         # Unknown notification received
         else:
             _LOGGER.warning("Unknown notification received (%s)", first_byte)
@@ -211,6 +223,32 @@ class Yeelock:
         _LOGGER.debug("Sent time sync msg %s", output_value)
         return output_value
 
+    def _encrypt_battery(self):
+        """Encrypt the battery request command."""
+        battery_command = 0x06
+        admin_identification_mode = 0x40
+        key = bytearray.fromhex(self.key)
+        timestamp = int(time())
+
+        message = (
+            battery_command.to_bytes(1, "big")
+            + admin_identification_mode.to_bytes(1, "big")
+            + timestamp.to_bytes(4, "big")
+        )
+        hmac_result = bytearray.fromhex(
+            hmac.new(key, message[:6], hashlib.sha1).hexdigest()
+        )[:14]
+
+        output_value = (
+            battery_command.to_bytes(1, "big")
+            + admin_identification_mode.to_bytes(1, "big")
+            + timestamp.to_bytes(4, "big")
+            + hmac_result
+        )
+
+        _LOGGER.debug("Sent battery msg %s", output_value)
+        return output_value
+
     async def locker(self, kind) -> None:
         """Lock, unlock and quick unlock the device."""
         self._last_action = kind  # Save action before attempting
@@ -232,6 +270,18 @@ class Yeelock:
             _LOGGER.debug("Time sync start")
             await self._client.write_gatt_char(
                 uuid.UUID(UUID_COMMAND), bytearray(self._encrypt_time())
+            )
+        except BleakError as error:
+            self._connected = False
+            _LOGGER.error("BleakError: %s", error)
+
+    async def update_battery(self) -> None:
+        """Request battery level."""
+        await self._connect()
+        try:
+            _LOGGER.debug("Requesting battery level")
+            await self._client.write_gatt_char(
+                uuid.UUID(UUID_COMMAND), bytearray(self._encrypt_battery())
             )
         except BleakError as error:
             self._connected = False

--- a/custom_components/yeelock/sensor.py
+++ b/custom_components/yeelock/sensor.py
@@ -34,6 +34,7 @@ class YeelockBatterySensor(YeelockDeviceEntity, SensorEntity):
     """Yeelock battery level sensor."""
 
     _attr_name = "Battery"
+    _attr_should_poll = False
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -43,10 +44,6 @@ class YeelockBatterySensor(YeelockDeviceEntity, SensorEntity):
         await super().async_added_to_hass()
         if self.device.battery_level is not None:
             self._attr_native_value = self.device.battery_level
-        await self.device.update_battery()
-
-    async def async_update(self) -> None:
-        """Update battery level."""
         await self.device.update_battery()
 
     async def _update_battery_level(self, new_level: int) -> None:

--- a/custom_components/yeelock/sensor.py
+++ b/custom_components/yeelock/sensor.py
@@ -1,0 +1,56 @@
+"""Yeelock sensors."""
+
+import logging
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .device import Yeelock, YeelockDeviceEntity
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+):
+    """Set up the Yeelock sensor platform."""
+    device: Yeelock = hass.data[DOMAIN][entry.unique_id]
+    battery_sensor = YeelockBatterySensor(device, hass)
+    device._battery_sensor = battery_sensor
+    async_add_entities([battery_sensor])
+    return True
+
+
+class YeelockBatterySensor(YeelockDeviceEntity, SensorEntity):
+    """Yeelock battery level sensor."""
+
+    _attr_name = "Battery"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added to hass."""
+        await super().async_added_to_hass()
+        if self.device.battery_level is not None:
+            self._attr_native_value = self.device.battery_level
+        await self.device.update_battery()
+
+    async def async_update(self) -> None:
+        """Update battery level."""
+        await self.device.update_battery()
+
+    async def _update_battery_level(self, new_level: int) -> None:
+        """Handle push updates from BLE notifications."""
+        _LOGGER.debug("Setting battery state to %s", new_level)
+        self._attr_native_value = new_level
+        self.async_write_ha_state()


### PR DESCRIPTION
### Motivation
- Expose the lock's battery level reported over BLE notifications so Home Assistant can display and refresh battery state. 
- Provide a way to actively request the battery value from the lock when entities are added or updated.

### Description
- Register the sensor platform by adding `Platform.SENSOR` to `PLATFORMS` in `custom_components/yeelock/const.py`.
- Add `YeelockBatterySensor` in `custom_components/yeelock/sensor.py` that requests battery on `async_added_to_hass`/`async_update` and accepts push updates via `_update_battery_level`.
- Extend the device implementation in `custom_components/yeelock/device.py` to store `battery_level`, keep a `_battery_sensor` reference, parse battery notifications starting with `0x07` and read the battery byte at index 6, and notify the sensor entity on updates.
- Implement `_encrypt_battery()` to build the battery request packet (`0x06 0x40 + timestamp + HMAC-SHA1`) and `update_battery()` to send the request over `UUID_COMMAND`.
- Remove the completed "Add battery level sensor" entry from the `README.md` future enhancements list.

### Testing
- Ran `bash ./scripts/lint` and the linter checks passed successfully.
- Ran `python -m compileall custom_components/yeelock` and all modules compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4dee729dc8327af21afe4b3b39c42)