### PR TITLE
Initialize `_last_action` in Yeelock to prevent AttributeError

### DIFF
--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -62,6 +62,7 @@ class Yeelock:
         self.model = config.get(CONF_MODEL, None)
         self.manufacturer = "Yeelock"
         self.battery_level = None
+        self._last_action = None
 
     async def disconnect(self):
         """Disconnect from the device."""


### PR DESCRIPTION
### Motivation
- The device handler can receive a time-sync-required notification before any lock action is requested, which allowed `_handle_data` to reference `self._last_action` before it existed and raise an `AttributeError`.

### Description
- Initialize `self._last_action = None` in `Yeelock.__init__` inside `custom_components/yeelock/device.py` so `_handle_data` can safely check and retry the last action.

### Testing
- Ran `python -m py_compile custom_components/yeelock/device.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e469e4688327bfcdf16cac07277d)