### PR TITLE
Avoid blocking Yeelock sensor setup during initial battery request

### DIFF
--- a/custom_components/yeelock/sensor.py
+++ b/custom_components/yeelock/sensor.py
@@ -44,7 +44,7 @@ class YeelockBatterySensor(YeelockDeviceEntity, SensorEntity):
         await super().async_added_to_hass()
         if self.device.battery_level is not None:
             self._attr_native_value = self.device.battery_level
-        await self.device.update_battery()
+        self.hass.async_create_task(self.device.update_battery())
 
     async def _update_battery_level(self, new_level: int) -> None:
         """Handle push updates from BLE notifications."""


### PR DESCRIPTION
### Motivation
- Prevent the Yeelock sensor entity setup from being blocked by a synchronous BLE battery refresh which can trigger the Home Assistant warning `Setup of sensor platform yeelock is taking over 10 seconds`.

### Description
- Run the initial battery refresh in the background by replacing `await self.device.update_battery()` with `self.hass.async_create_task(self.device.update_battery())` in `YeelockBatterySensor.async_added_to_hass` in `custom_components/yeelock/sensor.py`.

### Testing
- Ran `python -m compileall custom_components/yeelock/sensor.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e47380f88327ac58cf58c7f52397)