### PR TITLE
Handle transient BLE failures when initializing battery sensor

### DIFF
--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -236,8 +236,8 @@ class Yeelock:
 
     async def update_battery(self) -> None:
         """Request battery level from the lock over BLE."""
-        await self._connect()
         try:
+            await self._connect()
             _LOGGER.debug("Requesting battery level")
             await self._client.write_gatt_char(
                 uuid.UUID(UUID_COMMAND), bytearray(self._encrypt_battery())
@@ -245,3 +245,6 @@ class Yeelock:
         except BleakError as error:
             self._connected = False
             _LOGGER.error("BleakError: %s", error)
+        except Exception as error:  # pragma: no cover - backend-specific transient failures
+            self._connected = False
+            _LOGGER.warning("Unable to update battery for %s: %s", self.mac, error)

--- a/custom_components/yeelock/sensor.py
+++ b/custom_components/yeelock/sensor.py
@@ -44,7 +44,14 @@ class YeelockBatterySensor(YeelockDeviceEntity, SensorEntity):
         await super().async_added_to_hass()
         if self.device.battery_level is not None:
             self._attr_native_value = self.device.battery_level
-        await self.device.update_battery()
+        try:
+            await self.device.update_battery()
+        except Exception as error:  # pragma: no cover - defensive, device handles this too
+            _LOGGER.warning(
+                "Unable to fetch initial battery level for %s: %s",
+                self.device.mac,
+                error,
+            )
 
     async def _update_battery_level(self, new_level: int) -> None:
         """Handle push updates from BLE notifications."""


### PR DESCRIPTION
### Motivation
- Prevent entity registration from failing when a transient BLE transport error happens during the initial battery refresh. 
- Improve resilience to backend-specific connection errors that may not be wrapped as `BleakError`. 
- Ensure the integration logs and continues rather than raising during startup battery fetch.

### Description
- Wrap the initial battery fetch in `YeelockBatterySensor.async_added_to_hass` with a `try/except` that logs a warning on any exception so entity registration can complete. 
- Move the `await self._connect()` call into the `try` block inside `Yeelock.update_battery()` and add a broad `except Exception` handler that marks the device as disconnected and logs a warning for backend-specific transient failures. 
- Preserve the existing `BleakError` handling and add a defensive `# pragma: no cover` comment on the sensor-side catch.

### Testing
- Ran `python -m compileall custom_components/yeelock`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e47f93c08327b51fe4857a5a09e3)