### PR TITLE
Use bleak-retry-connector for Yeelock BLE connection setup

### DIFF
--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -9,6 +9,7 @@ from time import time
 
 from bleak import BleakClient
 from bleak.exc import BleakError
+from bleak_retry_connector import establish_connection
 from homeassistant.components import bluetooth
 from homeassistant.const import CONF_API_KEY, CONF_MAC, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -84,10 +85,14 @@ class Yeelock:
                     raise BleakError(
                         f"A device with address {self.mac} could not be found."
                     )
-                self._client = BleakClient(self._device)
                 _LOGGER.debug("Connecting to %s", self.mac)
-                await self._client.connect()
-                _LOGGER.debug("Connected", self.mac)
+                self._client = await establish_connection(
+                    BleakClient,
+                    self._device,
+                    self.mac,
+                    max_attempts=3,
+                )
+                _LOGGER.debug("Connected to %s", self.mac)
                 await self._client.start_notify(
                     uuid.UUID(UUID_NOTIFY), self._handle_data
                 )

--- a/custom_components/yeelock/manifest.json
+++ b/custom_components/yeelock/manifest.json
@@ -23,5 +23,8 @@
 	"integration_type": "device",
 	"iot_class": "local_push",
 	"issue_tracker": "https://github.com/codyc1515/ha-yeelock/issues",
-	"version": "2.2.0"
+	"version": "2.2.0",
+	"requirements": [
+		"bleak-retry-connector"
+	]
 }


### PR DESCRIPTION
### Motivation
- Home Assistant logs warn when integrations call `BleakClient.connect()` directly because it bypasses retry/backoff handling, which can lead to unreliable BLE connections.
- The change aims to use a retry-aware connector to make connection establishment more robust and to remove the warning.

### Description
- Import `establish_connection` from `bleak_retry_connector` and replace the direct `BleakClient.connect()` call with `await establish_connection(BleakClient, self._device, self.mac, max_attempts=3)` in `Yeelock._connect()` while preserving the existing notification subscription via `start_notify` in `custom_components/yeelock/device.py`.
- Update connection log messages to reflect the new connector usage (`"Connecting to %s"` and `"Connected to %s"`).
- Add `"bleak-retry-connector"` to the integration `manifest.json` `requirements` so the dependency is declared for the custom integration.

### Testing
- Ran `ruff check custom_components/yeelock/device.py`, which completed successfully.
- Ran `python -m compileall custom_components/yeelock/device.py custom_components/yeelock`, which compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e4cd06c083279a985361340bc1f0)