### PR TITLE
Serialize BLE connect attempts for Yeelock device

### DIFF
--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -1,5 +1,6 @@
 """Yeelock device."""
 
+import asyncio
 import hashlib
 import hmac
 import logging
@@ -55,6 +56,7 @@ class Yeelock:
         self._battery_sensor = None
         self._client = None
         self._connecting = False
+        self._connect_lock = asyncio.Lock()
         self._connected = False
         self.mac = config.get(CONF_MAC)
         self.name = config.get(CONF_NAME)
@@ -74,9 +76,12 @@ class Yeelock:
 
         :raises BleakError: if the device is not found
         """
-        self._connecting = True
-        try:
-            if (self._client is None) or (not self._client.is_connected):
+        async with self._connect_lock:
+            if self._client is not None and self._client.is_connected:
+                return
+
+            self._connecting = True
+            try:
                 self._device = bluetooth.async_ble_device_from_address(
                     self._hass, self.mac, connectable=True
                 )
@@ -92,10 +97,8 @@ class Yeelock:
                     uuid.UUID(UUID_NOTIFY), self._handle_data
                 )
                 _LOGGER.debug("Listening for notifications", self.mac)
-        except Exception as error:
-            self._connecting = False
-            raise error
-        self._connecting = False
+            finally:
+                self._connecting = False
 
     async def _handle_data(self, sender, value):
         """Handle data notifications."""


### PR DESCRIPTION
### Motivation
- Prevent races and scanner bookkeeping warnings caused by overlapping BLE connection attempts to a Yeelock device by serializing connect calls.

### Description
- Add `import asyncio` and a per-device `self._connect_lock = asyncio.Lock()` to the `Yeelock` class.
- Guard the connection flow in `_connect()` with `async with self._connect_lock` and short-circuit when `self._client` is already connected using an early `return`.
- Set `self._connecting = True` at the start of the guarded block and ensure it is always reset in a `finally` block so the flag cannot be left set after failures.
- Keep device discovery, `BleakClient` creation, `connect()`, and `start_notify()` behavior unchanged aside from the serialization.

### Testing
- Compiled the modified module with `python -m compileall custom_components/yeelock/device.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e4779f4c8327a115f3c5c5b473af)