### PR TITLE
Refactor config flow error handling and notification parsing; update Ruff lint config

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,7 @@
 
 target-version = "py310"
 
+[lint]
 select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
@@ -38,11 +39,11 @@ ignore = [
     "E731",  # do not assign a lambda expression, use a def
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[pyupgrade]
+[lint.pyupgrade]
 keep-runtime-typing = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25

--- a/custom_components/yeelock/config_flow.py
+++ b/custom_components/yeelock/config_flow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import aiohttp
 import async_timeout
-import asyncio
 import socket
 import logging
 from typing import Any
@@ -13,6 +12,7 @@ import voluptuous
 
 from bluetooth_data_tools import human_readable_name
 from homeassistant import config_entries
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import (
     CONF_COUNTRY_CODE,
     CONF_PASSWORD,
@@ -48,7 +48,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize Yeelock config flow."""
-        self._session = None  # Avoids unclosed client session
         self._schema = STEP_USER_DATA_SCHEMA
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
@@ -99,60 +98,60 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(address, raise_on_progress=False)
             self._abort_if_unique_id_configured()
 
-            # Get OAuth token
-            _LOGGER.debug("Get token")
-            login = await self._api_wrapper(
-                method="post",
-                url="https://api.yeeloc.com/oauth/access_token",
-                params={
-                    "grant_type": "password",
-                    "client_id": "yeeloc",
-                    "client_secret": "adb03414981961952ccf40a1b4031d12",
-                    "username": user_input[CONF_PHONE],
-                    "password": user_input[CONF_PASSWORD],
-                    "zone": user_input[CONF_COUNTRY_CODE],
-                },
-                headers={
-                    "content-type": "application/x-www-form-urlencoded; charset=UTF-8"
-                },
-            )
-
             try:
-                if login["access_token"]:
-                    # Get locks
-                    _LOGGER.debug("Get locks")
-                    locks = await self._api_wrapper(
-                        method="get",
-                        url="https://api.yeeloc.com/lock",
-                        headers={"Authorization": "Bearer " + login["access_token"]},
+                login = await self._api_wrapper(
+                    method="post",
+                    url="https://api.yeeloc.com/oauth/access_token",
+                    params={
+                        "grant_type": "password",
+                        "client_id": "yeeloc",
+                        "client_secret": "adb03414981961952ccf40a1b4031d12",
+                        "username": user_input[CONF_PHONE],
+                        "password": user_input[CONF_PASSWORD],
+                        "zone": user_input[CONF_COUNTRY_CODE],
+                    },
+                    headers={
+                        "content-type": "application/x-www-form-urlencoded; charset=UTF-8"
+                    },
+                )
+                token = login.get("access_token")
+                if not token:
+                    errors["base"] = "auth_error"
+                    return self.async_show_form(
+                        step_id="cloud", data_schema=self._schema, errors=errors
                     )
 
-                    _LOGGER.debug(locks)
-                    for lock in locks:
-                        if (
-                            self._discovery_info.name.removeprefix("EL_")
-                            == lock["lock_sn"]
-                        ):
-                            _LOGGER.debug("Found lock and key")
+                # Get locks
+                _LOGGER.debug("Get locks")
+                locks = await self._api_wrapper(
+                    method="get",
+                    url="https://api.yeeloc.com/lock",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
 
-                            user_input[CONF_API_KEY] = lock["ble_sign_key"]
-                            user_input[CONF_MAC] = address
-                            user_input[CONF_NAME] = lock["lock_name"]
-                            user_input[CONF_MODEL] = lock["lock_type"]
+                _LOGGER.debug(locks)
+                for lock in locks:
+                    if self._discovery_info.name.removeprefix("EL_") == lock["lock_sn"]:
+                        _LOGGER.debug("Found lock and key")
 
-                            await self._session.close()
+                        user_input[CONF_API_KEY] = lock["ble_sign_key"]
+                        user_input[CONF_MAC] = address
+                        user_input[CONF_NAME] = lock["lock_name"]
+                        user_input[CONF_MODEL] = lock["lock_type"]
 
-                            return self.async_create_entry(
-                                title=user_input[CONF_NAME], data=user_input
-                            )
-                    errors["base"] = "cannot_connect"
-                else:
-                    errors["base"] = "auth_error"
-            except KeyError:
+                        return self.async_create_entry(
+                            title=user_input[CONF_NAME], data=user_input
+                        )
+                errors["base"] = "cannot_connect"
+            except YeelockAuthError:
+                errors["base"] = "auth_error"
+            except YeelockApiError:
                 errors["base"] = "unknown"
 
             _LOGGER.warning("Failed cloud login")
-            return self.async_show_form(step_id="cloud", data_schema=self._schema)
+            return self.async_show_form(
+                step_id="cloud", data_schema=self._schema, errors=errors
+            )
         else:
             _LOGGER.debug("Showing cloud form")
             return self.async_show_form(
@@ -174,14 +173,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
-    ) -> any:
+    ) -> Any:
         """Get information from the API."""
-        if self._session is None:
-            self._session = aiohttp.ClientSession()
+        session = async_get_clientsession(self.hass)
 
         try:
             async with async_timeout.timeout(10):
-                response = await self._session.request(
+                response = await session.request(
                     method=method,
                     url=url,
                     data=data,
@@ -190,19 +188,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     headers=headers,
                 )
                 if response.status in (400, 401, 403):
-                    raise Exception(
-                        "Invalid credentials",
-                    )
+                    raise YeelockAuthError
                 response.raise_for_status()
                 return await response.json()
 
-        except asyncio.TimeoutError as exception:
-            raise Exception(
-                "Timeout error fetching information: %s", exception
-            ) from exception
+        except TimeoutError as exception:
+            raise YeelockApiError("Timeout error fetching information") from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
-            raise Exception("Error fetching information: %s", exception) from exception
-        except Exception as exception:  # pylint: disable=broad-except
-            raise Exception(
-                "Something really wrong happened! %s", exception
-            ) from exception
+            raise YeelockApiError("Error fetching information") from exception
+
+
+class YeelockApiError(Exception):
+    """Base API exception raised by the Yeelock integration."""
+
+
+class YeelockAuthError(YeelockApiError):
+    """Raised when authentication with the Yeelock cloud fails."""

--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -109,39 +109,37 @@ class Yeelock:
     async def _handle_data(self, sender, value):
         """Handle data notifications."""
         _LOGGER.debug("Received %s from %s", hexlify(value, " "), sender)  # noqa: E501
+        if not value:
+            _LOGGER.warning("Received empty notification from %s", sender)
+            return
         new_state = None
-
-        # Hex the received message
-        received_message = hexlify(value, " ")
-
-        # Extract the first element (index 0) and convert it to an integer
-        first_byte = hex(int(received_message.split()[0], 16))
+        first_byte = value[0]
 
         # Lock change successes
         # Unlocking
-        if first_byte == hex(0x2):
+        if first_byte == 0x2:
             new_state = "unlocking"
 
         # Unlocked
-        elif first_byte == hex(0x3):
+        elif first_byte == 0x3:
             new_state = "unlocked"
 
         # Locking
-        elif first_byte == hex(0x4):
+        elif first_byte == 0x4:
             new_state = "locking"
 
         # Locked
-        elif first_byte == hex(0x5):
+        elif first_byte == 0x5:
             new_state = "locked"
 
         # Lock change failures
         # Invalid signing key
-        elif first_byte == hex(0xFF):
+        elif first_byte == 0xFF:
             _LOGGER.error("Invalid signing key")
             new_state = "jammed"
 
         # Time needs to be synced
-        elif first_byte == hex(0x9):
+        elif first_byte == 0x9:
             _LOGGER.info("Lock reported time drift; syncing time")
             await self.time_sync()
             if self._last_action:
@@ -150,23 +148,24 @@ class Yeelock:
                 self._last_action = None
 
         # Battery response notification
-        elif first_byte == hex(0x7):
+        elif first_byte == 0x7:
             if len(value) > 6:
                 self.battery_level = value[6]
                 _LOGGER.debug("Received battery level: %s%%", self.battery_level)
                 if self._battery_sensor is not None:
                     await self._battery_sensor._update_battery_level(self.battery_level)
             else:
-                _LOGGER.warning("Battery notification too short: %s", received_message)
+                _LOGGER.warning("Battery notification too short: %s", hexlify(value, " "))
 
         # Unknown notification received
         else:
-            _LOGGER.warning("Unknown notification received (%s)", first_byte)
+            _LOGGER.warning("Unknown notification received (0x%02x)", first_byte)
 
         # Update to the new lock state, if we have one
         if new_state is not None:
             _LOGGER.debug("Notified of %s", new_state)
-            await self._lock._update_lock_state(new_state)
+            if self._lock is not None:
+                await self._lock._update_lock_state(new_state)
 
     def _encrypt_command(
         self, command: int, admin_identification_mode: int, payload: bytes = b""


### PR DESCRIPTION
### Motivation
- Reduce resource-leak risk and improve error clarity in the cloud auth flow by using Home Assistant's shared aiohttp session and clearer error types.
- Simplify BLE notification parsing to improve readability and avoid fragile string/hex parsing.
- Remove deprecated Ruff configuration keys to avoid tooling warnings and keep linting config current.

### Description
- Replaced per-flow `aiohttp.ClientSession` usage with `async_get_clientsession(self.hass)` in `config_flow.py` and removed manual session lifecycle management.
- Added `YeelockApiError` and `YeelockAuthError` exception classes and mapped API errors to flow form errors (`auth_error`, `cannot_connect`, `unknown`) and used `login.get("access_token")` to validate tokens.
- Improved `_api_wrapper` to raise typed exceptions for timeout and client errors and surface form errors consistently in the cloud step.
- Simplified BLE notification parsing in `device.py` to read the first byte directly via `value[0]`, added a guard for empty notifications, changed some log formatting, and avoid calling lock update if `_lock` is `None`.
- Migrated deprecated top-level Ruff keys into the new `[lint]` namespace in `.ruff.toml` to suppress deprecation warnings.

### Testing
- Ran `bash scripts/lint`, which completed with "All checks passed!".
- Ran `python -m compileall custom_components/yeelock`, which successfully compiled the package modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e6ac90f48327863daf927e0e1d61)