### PR TITLE
Use standard `invalid_auth` error in Yeelock config flow

### DIFF
--- a/custom_components/yeelock/config_flow.py
+++ b/custom_components/yeelock/config_flow.py
@@ -116,7 +116,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 token = login.get("access_token")
                 if not token:
-                    errors["base"] = "auth_error"
+                    errors["base"] = "invalid_auth"
                     return self.async_show_form(
                         step_id="cloud", data_schema=self._schema, errors=errors
                     )
@@ -144,7 +144,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         )
                 errors["base"] = "cannot_connect"
             except YeelockAuthError:
-                errors["base"] = "auth_error"
+                errors["base"] = "invalid_auth"
             except YeelockApiError:
                 errors["base"] = "unknown"
 


### PR DESCRIPTION
### Motivation
- Align error reporting in the Yeelock config flow with Home Assistant's standard error keys by replacing a custom `auth_error` with `invalid_auth` when cloud authentication fails.

### Description
- Replace occurrences of `errors["base"] = "auth_error"` with `errors["base"] = "invalid_auth"` in `custom_components/yeelock/config_flow.py` to normalize authentication error handling.

### Testing
- Ran project linting and the integration's config flow unit tests (`pytest`) against the modified file and the test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e865fd788327b18c475f3fda22d6)