### PR TITLE
Fix Yeelock device info to use Bluetooth connection type

### DIFF
--- a/custom_components/yeelock/device.py
+++ b/custom_components/yeelock/device.py
@@ -39,7 +39,7 @@ class YeelockDeviceEntity:
         """Shared device info information."""
         return {
             "identifiers": {(DOMAIN, self.device.mac)},
-            "connections": {(dr.CONNECTION_NETWORK_MAC, self.device.mac)},
+            "connections": {(dr.CONNECTION_BLUETOOTH, self.device.mac)},
             "name": self.device.name,
             "manufacturer": self.device.manufacturer,
             "model": self.device.model,


### PR DESCRIPTION
### Motivation
- Home Assistant was showing the device address as a network MAC, which is incorrect for BLE locks and should be represented as a Bluetooth connection.

### Description
- Change `device_info["connections"]` from `dr.CONNECTION_NETWORK_MAC` to `dr.CONNECTION_BLUETOOTH` in `custom_components/yeelock/device.py` so the device is registered as a Bluetooth connection.

### Testing
- Ran `python -m compileall custom_components/yeelock/device.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e9fba4a48327a4e7b8d91ec7e031)