### PR TITLE
Fix Ruff CI: use Python 3.13.2 in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v5.0.0
           with:
-            python-version: "3.11"
+            python-version: "3.13.2"
             cache: "pip"
 
         - name: "Install requirements"


### PR DESCRIPTION
### Motivation
- The lint job failed installing `homeassistant==2025.10.2` because the workflow used Python `3.11` while that Home Assistant version requires Python >= `3.13.2`, so the CI Python runtime needs to be updated.

### Description
- Update `.github/workflows/lint.yml` to set `python-version: "3.13.2"` (was `3.11`) so `pip install -r requirements.txt` can succeed with the pinned Home Assistant dependency.

### Testing
- Verified by running `export PYENV_VERSION=3.13.8; python -m pip install -r requirements.txt` which installed dependencies successfully and then `python -m ruff check .` which ran with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e9c2f2d083279acecf7dce64e15d)