### PR TITLE
Remove unsupported lock PIN code format

### DIFF
--- a/custom_components/yeelock/lock.py
+++ b/custom_components/yeelock/lock.py
@@ -40,11 +40,6 @@ class YeelockLock(YeelockDeviceEntity, LockEntity, RestoreEntity):
             self._attr_state = state.state
 
     @property
-    def code_format(self):
-        """Returns code format."""
-        return None
-
-    @property
     def is_locking(self):
         """Return true if lock is locking."""
         return self._attr_state == "locking"


### PR DESCRIPTION
### Motivation
- The integration was advertising PIN/code behavior via the lock entity which the hardware does not support, so the `code_format` hook needed to be removed.

### Description
- Remove the `code_format` property from the lock entity so Home Assistant no longer exposes PIN-code behavior for this lock; the lock now only exposes standard state/open behavior in `custom_components/yeelock/lock.py`.
- This is a small API surface cleanup and does not change the lock action methods or supported features (`LockEntityFeature.OPEN`).

### Testing
- Ran `python -m compileall custom_components/yeelock` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ee1e16288327b56f04096cf5ed20)