### PR TITLE
Fix Yeelock options flow initialization

### DIFF
--- a/custom_components/yeelock/config_flow.py
+++ b/custom_components/yeelock/config_flow.py
@@ -324,6 +324,10 @@ class YeelockAccountNotRegisteredError(YeelockAuthError):
 class YeelockOptionsFlow(config_entries.OptionsFlowWithReload):
     """Handle options for Yeelock."""
 
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:


### PR DESCRIPTION
### Motivation

- The options flow was failing to be instantiated with a `config_entry`, causing `TypeError: YeelockOptionsFlow() takes no arguments` when opening integration options. 

### Description

- Add an explicit `__init__(self, config_entry: config_entries.ConfigEntry)` to `YeelockOptionsFlow` and store the passed `config_entry` on the instance as `self.config_entry` so the options flow can access entry data and options. 
- Updated `custom_components/yeelock/config_flow.py` to use `self.config_entry` in `async_step_init` defaults as intended. 

### Testing

- Compiled the modified file with `python -m compileall custom_components/yeelock/config_flow.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f03f6ca48327bdcf308449155f5f)