### PR TITLE
Improve auto-config logging and guard against missing discovered device name

### DIFF
--- a/custom_components/yeelock/config_flow.py
+++ b/custom_components/yeelock/config_flow.py
@@ -112,10 +112,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_try_auto_configure_from_saved_account(self) -> FlowResult | None:
         """Try to configure from previously saved credentials."""
         if not self._discovery_info or not self._discovery_info.address:
+            _LOGGER.debug("Auto-config skipped: discovery info missing")
             return None
 
         saved = self._get_saved_account_data()
         if not saved:
+            _LOGGER.debug("Auto-config skipped: no previously saved credentials found")
             return None
 
         account = saved[CONF_PHONE]
@@ -147,6 +149,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 _LOGGER.debug("Auto-configured discovered lock using saved account")
                 return self.async_create_entry(title=auto_input[CONF_NAME], data=auto_input)
+            _LOGGER.debug(
+                "Auto-config skipped: discovered device name %s did not match any cloud lock",
+                self._discovery_info.name,
+            )
         except YeelockApiError:
             _LOGGER.debug("Saved account auto-configuration attempt failed")
 
@@ -188,8 +194,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         locks = locks_response.get("data", [])
         _LOGGER.debug(locks_response)
+        discovered_name = self._discovery_info.name
+        if not discovered_name:
+            _LOGGER.debug("Unable to match lock: discovered bluetooth device name is missing")
+            return None
         for lock in locks:
-            if self._discovery_info.name.removeprefix("EL_") == lock["sn"]:
+            if discovered_name.removeprefix("EL_") == lock["sn"]:
                 return lock
         return None
 


### PR DESCRIPTION
### Motivation
- Improve troubleshooting and robustness of the automatic provisioning flow when a discovered Bluetooth lock is matched to a previously saved cloud account by providing clearer debug messages and handling missing discovery name values.

### Description
- Add debug logs in `async_try_auto_configure_from_saved_account` for missing discovery info and missing saved credentials.
- Log when the discovered device name does not match any cloud lock during the auto-config attempt in `async_try_auto_configure_from_saved_account`.
- Add a guard and debug log in `_async_get_matching_lock` to handle a missing discovered Bluetooth device name and use a local `discovered_name` variable when comparing serial numbers.

### Testing
- No new automated tests were added for this change and the existing automated test suite for the integration was exercised and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f14d68b483278458ce97aa30d948)