### PR TITLE
Persist Yeelock cloud accounts and improve auto-provisioning & matching

### DIFF
--- a/custom_components/yeelock/config_flow.py
+++ b/custom_components/yeelock/config_flow.py
@@ -14,6 +14,7 @@ from bluetooth_data_tools import human_readable_name
 from homeassistant import config_entries
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.storage import Store
 from homeassistant.const import (
     CONF_COUNTRY_CODE,
     CONF_PASSWORD,
@@ -39,6 +40,10 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ACCOUNT_TYPE = "account_type"
 ACCOUNT_TYPE_EMAIL = "email"
 ACCOUNT_TYPE_PHONE = "phone"
+CONF_ACCOUNT_ID = "account_id"
+
+ACCOUNT_STORE_KEY = f"{DOMAIN}_accounts"
+ACCOUNT_STORE_VERSION = 1
 
 STEP_USER_DATA_SCHEMA = voluptuous.Schema(
     {
@@ -97,8 +102,44 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Handoff to account type step")
         return await self.async_step_account_type()
 
-    def _get_saved_account_data(self) -> dict[str, Any] | None:
-        """Get a previously configured Yeelock account payload."""
+    @staticmethod
+    def _build_account_id(account: str) -> str:
+        """Build a stable account id."""
+        return account.strip().lower()
+
+    @staticmethod
+    def _build_login_account(saved_account: dict[str, Any]) -> str:
+        """Build the cloud login account string for API auth."""
+        if saved_account.get(CONF_COUNTRY_CODE):
+            return f"{saved_account[CONF_COUNTRY_CODE]} {saved_account[CONF_PHONE]}"
+        return saved_account[CONF_PHONE]
+
+    @staticmethod
+    def _sanitize_account_for_store(saved_account: dict[str, Any]) -> dict[str, Any]:
+        """Persist only account fields that should be reused by auto-discovery."""
+        sanitized: dict[str, Any] = {
+            CONF_ACCOUNT_ID: saved_account[CONF_ACCOUNT_ID],
+            CONF_PHONE: saved_account[CONF_PHONE],
+            CONF_PASSWORD: saved_account[CONF_PASSWORD],
+        }
+        if saved_account.get(CONF_COUNTRY_CODE):
+            sanitized[CONF_COUNTRY_CODE] = saved_account[CONF_COUNTRY_CODE]
+        return sanitized
+
+    async def _async_get_saved_accounts_data(self) -> list[dict[str, Any]]:
+        """Get all previously saved Yeelock account payloads."""
+        store = Store[dict[str, Any]](self.hass, ACCOUNT_STORE_VERSION, ACCOUNT_STORE_KEY)
+        stored_data = await store.async_load() or {}
+        stored_accounts = stored_data.get("accounts", [])
+        if stored_accounts:
+            return [
+                account
+                for account in stored_accounts
+                if account.get(CONF_PHONE) and account.get(CONF_PASSWORD)
+            ]
+
+        # Legacy fallback: first configured lock entry used to hold cloud credentials.
+        migrated_accounts: list[dict[str, Any]] = []
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if (
                 CONF_PHONE in entry.data
@@ -106,49 +147,86 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 and entry.data[CONF_PHONE]
                 and entry.data[CONF_PASSWORD]
             ):
-                return dict(entry.data)
-        return None
+                account: dict[str, Any] = {
+                    CONF_PHONE: entry.data[CONF_PHONE],
+                    CONF_PASSWORD: entry.data[CONF_PASSWORD],
+                }
+                if entry.data.get(CONF_COUNTRY_CODE):
+                    account[CONF_COUNTRY_CODE] = entry.data[CONF_COUNTRY_CODE]
+                account_id = self._build_account_id(self._build_login_account(account))
+                account[CONF_ACCOUNT_ID] = account_id
+                migrated_accounts.append(self._sanitize_account_for_store(account))
+
+        if migrated_accounts:
+            await store.async_save({"accounts": migrated_accounts})
+            _LOGGER.debug("Migrated %s Yeelock cloud account(s) to account store", len(migrated_accounts))
+
+        return migrated_accounts
+
+    async def _async_save_account_data(self, account_data: dict[str, Any]) -> None:
+        """Save or update account credentials in persistent account store."""
+        store = Store[dict[str, Any]](self.hass, ACCOUNT_STORE_VERSION, ACCOUNT_STORE_KEY)
+        stored_data = await store.async_load() or {}
+        accounts = stored_data.get("accounts", [])
+        account_id = account_data[CONF_ACCOUNT_ID]
+
+        sanitized = self._sanitize_account_for_store(account_data)
+        updated = False
+        for index, existing in enumerate(accounts):
+            if existing.get(CONF_ACCOUNT_ID) == account_id:
+                accounts[index] = sanitized
+                updated = True
+                break
+        if not updated:
+            accounts.append(sanitized)
+
+        await store.async_save({"accounts": accounts})
+
+    @staticmethod
+    def _normalize_identifier(value: str | None) -> str:
+        """Normalize lock identifiers for reliable comparisons."""
+        if not value:
+            return ""
+        normalized = value.strip().upper()
+        if normalized.startswith("EL_"):
+            normalized = normalized.removeprefix("EL_")
+        return normalized.replace(":", "").replace("-", "").replace("_", "")
 
     async def _async_try_auto_configure_from_saved_account(self) -> FlowResult | None:
         """Try to configure from previously saved credentials."""
         if not self._discovery_info or not self._discovery_info.address:
+            _LOGGER.debug("Auto-config skipped: discovery info missing")
             return None
 
-        saved = self._get_saved_account_data()
-        if not saved:
+        saved_accounts = await self._async_get_saved_accounts_data()
+        if not saved_accounts:
+            _LOGGER.debug("Auto-config skipped: no previously saved credentials found")
             return None
 
-        account = saved[CONF_PHONE]
-        if CONF_COUNTRY_CODE in saved and saved[CONF_COUNTRY_CODE]:
-            account = f"{saved[CONF_COUNTRY_CODE]} {saved[CONF_PHONE]}"
+        for saved in saved_accounts:
+            account = self._build_login_account(saved)
+            try:
+                token = await self._async_login_and_get_token(account, saved[CONF_PASSWORD])
+                lock = await self._async_get_matching_lock(token)
+                if lock:
+                    auto_input: dict[str, Any] = {
+                        CONF_ACCOUNT_ID: saved[CONF_ACCOUNT_ID],
+                        CONF_API_KEY: lock["ble_sign_key"],
+                        CONF_MAC: self._discovery_info.address,
+                        CONF_NAME: lock["name"],
+                        CONF_MODEL: lock["type"],
+                        CONF_AUTO_UNLOCK_LOW_BATTERY: DEFAULT_AUTO_UNLOCK_LOW_BATTERY,
+                        CONF_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD: DEFAULT_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD,
+                    }
+                    _LOGGER.debug("Auto-configured discovered lock using saved account")
+                    return self.async_create_entry(title=auto_input[CONF_NAME], data=auto_input)
+            except YeelockApiError:
+                _LOGGER.debug("Saved account auto-configuration attempt failed")
 
-        try:
-            token = await self._async_login_and_get_token(account, saved[CONF_PASSWORD])
-            lock = await self._async_get_matching_lock(token)
-            if lock:
-                auto_input: dict[str, Any] = {
-                    CONF_PHONE: saved[CONF_PHONE],
-                    CONF_PASSWORD: saved[CONF_PASSWORD],
-                    CONF_API_KEY: lock["ble_sign_key"],
-                    CONF_MAC: self._discovery_info.address,
-                    CONF_NAME: lock["name"],
-                    CONF_MODEL: lock["type"],
-                    CONF_AUTO_UNLOCK_LOW_BATTERY: saved.get(
-                        CONF_AUTO_UNLOCK_LOW_BATTERY,
-                        DEFAULT_AUTO_UNLOCK_LOW_BATTERY,
-                    ),
-                    CONF_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD: saved.get(
-                        CONF_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD,
-                        DEFAULT_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD,
-                    ),
-                }
-                if CONF_COUNTRY_CODE in saved:
-                    auto_input[CONF_COUNTRY_CODE] = saved[CONF_COUNTRY_CODE]
-
-                _LOGGER.debug("Auto-configured discovered lock using saved account")
-                return self.async_create_entry(title=auto_input[CONF_NAME], data=auto_input)
-        except YeelockApiError:
-            _LOGGER.debug("Saved account auto-configuration attempt failed")
+        _LOGGER.debug(
+            "Auto-config skipped: discovered device name %s did not match any cloud lock",
+            self._discovery_info.name,
+        )
 
         return None
 
@@ -188,8 +266,31 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         locks = locks_response.get("data", [])
         _LOGGER.debug(locks_response)
+        discovered_name = self._discovery_info.name
+        discovered_address = self._discovery_info.address
+        normalized_discovered_name = self._normalize_identifier(discovered_name)
+        normalized_discovered_address = self._normalize_identifier(discovered_address)
+        if not discovered_name:
+            _LOGGER.debug("Unable to match lock: discovered bluetooth device name is missing")
+
         for lock in locks:
-            if self._discovery_info.name.removeprefix("EL_") == lock["sn"]:
+            lock_identifiers = {
+                self._normalize_identifier(lock.get("sn")),
+                self._normalize_identifier(lock.get("name")),
+                self._normalize_identifier(lock.get("mac")),
+                self._normalize_identifier(lock.get("ble_mac")),
+                self._normalize_identifier(lock.get("bluetooth_mac")),
+                self._normalize_identifier(lock.get("bt_mac")),
+            }
+            lock_identifiers.discard("")
+
+            if (
+                normalized_discovered_name
+                and normalized_discovered_name in lock_identifiers
+            ) or (
+                normalized_discovered_address
+                and normalized_discovered_address in lock_identifiers
+            ):
                 return lock
         return None
 
@@ -292,13 +393,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 lock = await self._async_get_matching_lock(token)
                 if lock:
                     _LOGGER.debug("Found lock and key")
-                    user_input[CONF_API_KEY] = lock["ble_sign_key"]
-                    user_input[CONF_MAC] = address
-                    user_input[CONF_NAME] = lock["name"]
-                    user_input[CONF_MODEL] = lock["type"]
+                    account_id = self._build_account_id(account)
+                    account_data = {
+                        CONF_ACCOUNT_ID: account_id,
+                        CONF_PHONE: user_input[CONF_PHONE],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    }
+                    if is_phone:
+                        account_data[CONF_COUNTRY_CODE] = user_input[CONF_COUNTRY_CODE]
+                    await self._async_save_account_data(account_data)
+
+                    entry_data: dict[str, Any] = {
+                        CONF_ACCOUNT_ID: account_id,
+                        CONF_AUTO_UNLOCK_LOW_BATTERY: user_input.get(
+                            CONF_AUTO_UNLOCK_LOW_BATTERY,
+                            DEFAULT_AUTO_UNLOCK_LOW_BATTERY,
+                        ),
+                        CONF_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD: user_input.get(
+                            CONF_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD,
+                            DEFAULT_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD,
+                        ),
+                    }
+                    entry_data[CONF_MAC] = address
+                    entry_data[CONF_NAME] = lock["name"]
+                    entry_data[CONF_MODEL] = lock["type"]
+                    entry_data[CONF_API_KEY] = lock["ble_sign_key"]
 
                     return self.async_create_entry(
-                        title=user_input[CONF_NAME], data=user_input
+                        title=entry_data[CONF_NAME], data=entry_data
                     )
                 errors["base"] = "cannot_connect"
             except YeelockAccountNotRegisteredError:


### PR DESCRIPTION
### Motivation
- Persist cloud credentials so newly discovered locks can be auto-provisioned with previously used accounts.
- Improve reliability of matching a discovered Bluetooth lock to cloud locks by normalizing identifiers and comparing multiple fields.
- Provide a migration path from legacy credential storage in a lock entry to a dedicated account store.

### Description
- Add a persistent account store using `Store` with keys `ACCOUNT_STORE_KEY` and version `ACCOUNT_STORE_VERSION`, and functions to save and load sanitized account payloads (`_async_save_account_data`, `_async_get_saved_accounts_data`, `_sanitize_account_for_store`).
- Introduce stable account identifiers via `_build_account_id` and build cloud login strings via `_build_login_account` and sanitize stored accounts to only required fields.
- Replace legacy `_get_saved_account_data` logic with a migration that reads existing config entries, migrates credentials into the account store, and logs the migration.
- Improve auto-configuration flow to iterate over saved accounts, attempt cloud login for each, and create entries when the discovered device matches a cloud lock; save account data on manual login to the account store.
- Add identifier normalization (`_normalize_identifier`) and update `_async_get_matching_lock` to compare normalized discovered device name/address against multiple lock identifier fields (`sn`, `name`, `mac`, `ble_mac`, `bluetooth_mac`, `bt_mac`) and handle `EL_` prefixes and separators.
- Add additional debug logging to clarify auto-config decisions and failures.

### Testing
- Ran the component's automated tests with `pytest` targeting the Yeelock integration; the test run completed and all tests passed.
- Verified that the migration path executes when legacy credential-bearing entries exist by running the flow in the test environment and confirming migrated accounts were stored successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f14d68b483278458ce97aa30d948)