### PR TITLE
Require user confirmation for Bluetooth-discovered locks and add i18n strings

### DIFF
--- a/custom_components/yeelock/config_flow.py
+++ b/custom_components/yeelock/config_flow.py
@@ -94,13 +94,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         }
 
-        # If this account was already configured for another lock, try to
-        # automatically provision this newly discovered lock.
-        if auto_entry := await self._async_try_auto_configure_from_saved_account():
-            return auto_entry
+        return await self.async_step_bluetooth_confirm()
 
-        _LOGGER.debug("Handoff to account type step")
-        return await self.async_step_account_type()
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm configuring a bluetooth-discovered lock."""
+        if user_input is not None:
+            if auto_entry := await self._async_try_auto_configure_from_saved_account():
+                return auto_entry
+
+            _LOGGER.debug("Handoff to account type step")
+            return await self.async_step_account_type()
+
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            data_schema=voluptuous.Schema({}),
+        )
 
     @staticmethod
     def _build_account_id(account: str) -> str:
@@ -159,7 +169,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if migrated_accounts:
             await store.async_save({"accounts": migrated_accounts})
-            _LOGGER.debug("Migrated %s Yeelock cloud account(s) to account store", len(migrated_accounts))
+            _LOGGER.debug(
+                "Migrated %s Yeelock cloud account(s) to account store",
+                len(migrated_accounts),
+            )
 
         return migrated_accounts
 
@@ -218,8 +231,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_AUTO_UNLOCK_LOW_BATTERY: DEFAULT_AUTO_UNLOCK_LOW_BATTERY,
                         CONF_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD: DEFAULT_AUTO_UNLOCK_LOW_BATTERY_THRESHOLD,
                     }
-                    _LOGGER.debug("Auto-configured discovered lock using saved account")
-                    return self.async_create_entry(title=auto_input[CONF_NAME], data=auto_input)
+                    _LOGGER.debug(
+                        "Auto-configured discovered lock using saved account"
+                    )
+                    return self.async_create_entry(
+                        title=auto_input[CONF_NAME], data=auto_input
+                    )
             except YeelockApiError:
                 _LOGGER.debug("Saved account auto-configuration attempt failed")
 

--- a/custom_components/yeelock/strings.json
+++ b/custom_components/yeelock/strings.json
@@ -11,6 +11,10 @@
 			"unknown": "[%key:common::config_flow::error::unknown%]"
 		},
 		"step": {
+			"bluetooth_confirm": {
+				"title": "Yeelock",
+				"description": "Configure the discovered lock."
+			},
 			"account_type": {
 				"title": "Yeelock",
 				"description": "How do you sign in to the Yeelock app?",

--- a/custom_components/yeelock/translations/en.json
+++ b/custom_components/yeelock/translations/en.json
@@ -11,6 +11,10 @@
 			"unknown": "Unexpected error"
 		},
 		"step": {
+			"bluetooth_confirm": {
+				"title": "Yeelock",
+				"description": "Configure the discovered lock."
+			},
 			"account_type": {
 				"title": "Yeelock",
 				"description": "How do you sign in to the Yeelock app?",

--- a/custom_components/yeelock/translations/pt.json
+++ b/custom_components/yeelock/translations/pt.json
@@ -11,6 +11,10 @@
 			"unknown": "Erro desconhecido"
 		},
 		"step": {
+			"bluetooth_confirm": {
+				"title": "Yeelock",
+				"description": "Configurar a fechadura descoberta."
+			},
 			"account_type": {
 				"title": "Yeelock",
 				"description": "Como faz login na app Yeelock?",


### PR DESCRIPTION
### Motivation
- Require an explicit user confirmation before attempting to auto-configure a lock discovered over Bluetooth so the user can opt into using stored cloud credentials.  
- Surface a small confirmation UI step for discovered locks to make the flow clearer to users.  
- Add localized UI strings for the new confirmation step and tidy a few debug log messages for readability.

### Description
- Introduce a new flow handler `async_step_bluetooth_confirm` and have `async_step_bluetooth` immediately hand off to it instead of performing auto-configuration directly.  
- Move the saved-account auto-configuration attempt into `async_step_bluetooth_confirm` so it runs after the user confirms, and show an empty confirmation form via `async_show_form`.  
- Add `bluetooth_confirm` entries to `custom_components/yeelock/strings.json` and translations in `translations/en.json` and `translations/pt.json`.  
- Minor formatting cleanups for multi-line `_LOGGER.debug` calls and wrapped `async_create_entry` arguments for readability.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f93593d08327b01660a352d66f40)